### PR TITLE
Make sure the fields we are looking for in Fortify exist before we parse the element

### DIFF
--- a/heimdall_tools
+++ b/heimdall_tools
@@ -1,1 +1,0 @@
-exe/heimdall_tools

--- a/heimdall_tools
+++ b/heimdall_tools
@@ -1,0 +1,1 @@
+exe/heimdall_tools

--- a/lib/heimdall_tools/fortify_mapper.rb
+++ b/lib/heimdall_tools/fortify_mapper.rb
@@ -43,7 +43,11 @@ module HeimdallTools
         traces.each do |trace|
           entries = trace['Primary']['Entry']
           entries = [entries] unless entries.is_a?(Array)
-          entries = entries.reject { |x| x['Node'].nil? }
+          # This is just regular array access, it is just written in a manner that allows us
+          # to use Ruby's safe navigation operator. We rely on
+          # entry['Node']['SourceLocation']['snippet'] to exist on all of our entries, so if any
+          # of those are empty we reject that element.
+          entries = entries.reject { |x| x&.[]('Node')&.[]('SourceLocation')&.[]('snippet').nil? }
           entries.each do |entry|
             findings << process_entry(entry)
           end


### PR DESCRIPTION
This fixes an issue where FVDL files can sometimes have Entries with no SourceLocation. In that case we just go ahead and skip those entries.