### PR TITLE
Added default NIST_ID tags of SA-11 and RA-5 to sonarqube_mapper

### DIFF
--- a/lib/heimdall_tools/fortify_mapper.rb
+++ b/lib/heimdall_tools/fortify_mapper.rb
@@ -3,7 +3,7 @@ require 'heimdall_tools/hdf'
 require 'utilities/xml_to_hash'
 
 NIST_REFERENCE_NAME = 'Standards Mapping - NIST Special Publication 800-53 Revision 4'.freeze
-DEFAULT_NIST_TAG = ["SA-11", "RA-5", "Rev_4"].freeze
+DEFAULT_NIST_TAG = ["SA-11", "RA-5"].freeze
 
 module HeimdallTools
   class FortifyMapper

--- a/lib/heimdall_tools/fortify_mapper.rb
+++ b/lib/heimdall_tools/fortify_mapper.rb
@@ -3,6 +3,7 @@ require 'heimdall_tools/hdf'
 require 'utilities/xml_to_hash'
 
 NIST_REFERENCE_NAME = 'Standards Mapping - NIST Special Publication 800-53 Revision 4'.freeze
+DEFAULT_NIST_TAG = ["SA-11", "RA-5", "Rev_4"].freeze
 
 module HeimdallTools
   class FortifyMapper
@@ -68,7 +69,7 @@ module HeimdallTools
       references = rule['References']['Reference']
       references = [references] unless references.is_a?(Array)
       tag = references.detect { |x| x['Author'].eql?(NIST_REFERENCE_NAME) }
-      tag.nil? ? 'unmapped' : tag['Title'].match(/[a-zA-Z][a-zA-Z]-\d{1,2}/)
+      tag.nil? ? DEFAULT_NIST_TAG : tag['Title'].match(/[a-zA-Z][a-zA-Z]-\d{1,2}/)
     end
 
     def impact(classid)

--- a/lib/heimdall_tools/sonarqube_mapper.rb
+++ b/lib/heimdall_tools/sonarqube_mapper.rb
@@ -5,6 +5,8 @@ require 'heimdall_tools/hdf'
 
 RESOURCE_DIR = Pathname.new(__FILE__).join('../../data')
 
+DEFAULT_NIST_TAG = ["SA-11", "RA-5", "Rev_4"].freeze
+
 MAPPING_FILES = {
   cwe: File.join(RESOURCE_DIR, 'cwe-nist-mapping.csv'),
   owasp: File.join(RESOURCE_DIR, 'owasp-nist-mapping.csv')
@@ -237,7 +239,7 @@ class Control
       return [@mappings[tag_type][parsed_tag]].flatten.uniq
     end
 
-    ['unmapped'] # HDF expects this to be a list, but not an empty list even if there aren't results
+    DEFAULT_NIST_TAG # Entries with unmapped NIST tags are defaulted to NIST tags ‘SA-11, RA-5 Rev_4’
   end
 
   def hdf

--- a/lib/heimdall_tools/sonarqube_mapper.rb
+++ b/lib/heimdall_tools/sonarqube_mapper.rb
@@ -5,7 +5,7 @@ require 'heimdall_tools/hdf'
 
 RESOURCE_DIR = Pathname.new(__FILE__).join('../../data')
 
-DEFAULT_NIST_TAG = ["SA-11", "RA-5", "Rev_4"].freeze
+DEFAULT_NIST_TAG = ["SA-11", "RA-5"].freeze
 
 MAPPING_FILES = {
   cwe: File.join(RESOURCE_DIR, 'cwe-nist-mapping.csv'),

--- a/lib/heimdall_tools/zap_mapper.rb
+++ b/lib/heimdall_tools/zap_mapper.rb
@@ -7,7 +7,7 @@ require 'heimdall_tools/hdf'
 RESOURCE_DIR = Pathname.new(__FILE__).join('../../data')
 
 CWE_NIST_MAPPING_FILE = File.join(RESOURCE_DIR, 'cwe-nist-mapping.csv')
-DEFAULT_NIST_TAG = ["SA-11", "RA-5", "Rev_4"].freeze
+DEFAULT_NIST_TAG = ["SA-11", "RA-5"].freeze
 
 # rubocop:disable Metrics/AbcSize
 

--- a/lib/heimdall_tools/zap_mapper.rb
+++ b/lib/heimdall_tools/zap_mapper.rb
@@ -7,6 +7,7 @@ require 'heimdall_tools/hdf'
 RESOURCE_DIR = Pathname.new(__FILE__).join('../../data')
 
 CWE_NIST_MAPPING_FILE = File.join(RESOURCE_DIR, 'cwe-nist-mapping.csv')
+DEFAULT_NIST_TAG = ["SA-11", "RA-5", "Rev_4"].freeze
 
 # rubocop:disable Metrics/AbcSize
 
@@ -66,7 +67,7 @@ module HeimdallTools
     def nist_tag(cweid)
       entries = @cwe_nist_mapping.select { |x| x[:cweid].to_s.eql?(cweid.to_s) }
       tags = entries.map { |x| [x[:nistid], "Rev_#{x[:rev]}"] }
-      tags.empty? ? ['unmapped'] : tags.flatten.uniq
+      tags.empty? ? DEFAULT_NIST_TAG : tags.flatten.uniq
     end
 
     def impact(riskcode)


### PR DESCRIPTION
Added default NIST_ID tags of SA-11 and RA-5 to sonarqube_mapper
closes #24 