### PR TITLE
Nori is not a dependency of heimdall_tools

### DIFF
--- a/heimdall_tools.gemspec
+++ b/heimdall_tools.gemspec
@@ -32,7 +32,6 @@ Gem::Specification.new do |spec| # rubocop:disable Metrics/BlockLength
   spec.add_runtime_dependency 'csv', '~> 3.1'
   spec.add_runtime_dependency 'httparty', '~> 0.18.0'
   spec.add_runtime_dependency 'openssl', '~> 2.1'
-  spec.add_runtime_dependency 'nori', '~> 2.6'
   spec.add_runtime_dependency 'git-lite-version-bump', '>= 0.17.2'
   spec.add_development_dependency 'bundler'
   spec.add_development_dependency 'minitest', '~> 5.0'


### PR DESCRIPTION
Since it is no longer needed, removing it from the Gemspec.