### PR TITLE
Bug Fix: aws_config_mapper#check_text function

### DIFF
--- a/lib/heimdall_tools/aws_config_mapper.rb
+++ b/lib/heimdall_tools/aws_config_mapper.rb
@@ -257,8 +257,10 @@ module HeimdallTools
     end
 
     def check_text(config_rule)
-      params = (JSON.parse(config_rule[:input_parameters]).map { |key, value| "#{key}: #{value}" }).join('<br/>')
-      check_text = config_rule[:config_rule_arn]
+      # If no input parameters, then provide an empty JSON array to the JSON
+      # parser because passing nil to JSON.parse throws an exception.
+      params = (JSON.parse(config_rule[:input_parameters] || '[]').map { |key, value| "#{key}: #{value}" }).join('<br/>')
+      check_text = config_rule[:config_rule_arn] || ''
       check_text += "<br/>#{params}" unless params.empty?
       check_text
     end


### PR DESCRIPTION
Added a bug fix for aws_config_mapper#check_text function if a config rule's input_parameters are nil.

I ran into this issue during a deployment in a new environment and was able to fix it with these changes.