### PR TITLE
Do not lock nokogiri to 1.10, it has open CVEs

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,7 +7,7 @@ on:
     branches: [ master ]
 
 jobs:
-  lint:
+  test:
     strategy:
       matrix:
         platform: [ubuntu-16.04, ubuntu-latest, macos-latest, windows-latest]

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -3,7 +3,7 @@ inherit_from: .rubocop_todo.yml
 
 AllCops:
   NewCops: enable
-  TargetRubyVersion: 2.4
+  TargetRubyVersion: 2.5
   Exclude:
   - Gemfile
   - Rakefile

--- a/heimdall_tools.gemspec
+++ b/heimdall_tools.gemspec
@@ -33,7 +33,7 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency 'git-lite-version-bump', '>= 0.17.2'
   spec.add_runtime_dependency 'httparty', '~> 0.18.0'
   spec.add_runtime_dependency 'json', '~> 2.3'
-  spec.add_runtime_dependency 'nokogiri', '~> 1.10.9'
+  spec.add_runtime_dependency 'nokogiri', '~> 1.11'
   spec.add_runtime_dependency 'openssl', '~> 2.1'
   spec.add_runtime_dependency 'thor', '~> 0.19'
   spec.add_development_dependency 'bundler'


### PR DESCRIPTION
This is necessary for the IronBank hardening pipeline to pass.