### PR TITLE
Removed unused verbose parameter

### DIFF
--- a/lib/heimdall_tools/aws_config_mapper.rb
+++ b/lib/heimdall_tools/aws_config_mapper.rb
@@ -18,8 +18,7 @@ INSUFFICIENT_DATA_MSG = 'Not enough data has been collectd to determine complian
 #
 module HeimdallTools
   class AwsConfigMapper
-    def initialize(custom_mapping, endpoint = nil, verbose = false)
-      @verbose = verbose
+    def initialize(custom_mapping, endpoint = nil)
       @default_mapping = get_rule_mapping(AWS_CONFIG_MAPPING_FILE)
       @custom_mapping = custom_mapping.nil? ? {} : get_rule_mapping(custom_mapping)
       if endpoint.nil?

--- a/lib/heimdall_tools/burpsuite_mapper.rb
+++ b/lib/heimdall_tools/burpsuite_mapper.rb
@@ -20,9 +20,8 @@ DEFAULT_NIST_TAG = %w{SA-11 RA-5 Rev_4}.freeze
 
 module HeimdallTools
   class BurpSuiteMapper
-    def initialize(burps_xml, _name = nil, verbose = false)
+    def initialize(burps_xml, _name = nil)
       @burps_xml = burps_xml
-      @verbose = verbose
 
       begin
         @cwe_nist_mapping = parse_mapper

--- a/lib/heimdall_tools/cli.rb
+++ b/lib/heimdall_tools/cli.rb
@@ -6,7 +6,6 @@ module HeimdallTools
     long_desc Help.text(:fortify_mapper)
     option :fvdl, required: true, aliases: '-f'
     option :output, required: true, aliases: '-o'
-    option :verbose, type: :boolean, aliases: '-V'
     def fortify_mapper
       hdf = HeimdallTools::FortifyMapper.new(File.read(options[:fvdl])).to_hdf
       File.write(options[:output], hdf)
@@ -17,7 +16,6 @@ module HeimdallTools
     option :json, required: true, aliases: '-j'
     option :name, required: true, aliases: '-n'
     option :output, required: true, aliases: '-o'
-    option :verbose, type: :boolean, aliases: '-V'
     def zap_mapper
       hdf = HeimdallTools::ZapMapper.new(File.read(options[:json]), options[:name]).to_hdf
       File.write(options[:output], hdf)
@@ -29,7 +27,6 @@ module HeimdallTools
     option :api_url, required: true, aliases: '-u'
     option :auth, type: :string, required: false
     option :output, required: true, aliases: '-o'
-    option :verbose, type: :boolean, aliases: '-V'
     def sonarqube_mapper
       hdf = HeimdallTools::SonarQubeMapper.new(options[:name], options[:api_url], options[:auth]).to_hdf
       File.write(options[:output], hdf)
@@ -39,7 +36,6 @@ module HeimdallTools
     long_desc Help.text(:burpsuite_mapper)
     option :xml, required: true, aliases: '-x'
     option :output, required: true, aliases: '-o'
-    option :verbose, type: :boolean, aliases: '-V'
     def burpsuite_mapper
       hdf = HeimdallTools::BurpSuiteMapper.new(File.read(options[:xml])).to_hdf
       File.write(options[:output], hdf)
@@ -49,7 +45,6 @@ module HeimdallTools
     long_desc Help.text(:nessus_mapper)
     option :xml, required: true, aliases: '-x'
     option :output_prefix, required: true, aliases: '-o'
-    option :verbose, type: :boolean, aliases: '-V'
     def nessus_mapper
       hdfs = HeimdallTools::NessusMapper.new(File.read(options[:xml])).to_hdf
 
@@ -64,7 +59,6 @@ module HeimdallTools
     long_desc Help.text(:snyk_mapper)
     option :json, required: true, aliases: '-j'
     option :output_prefix, required: true, aliases: '-o'
-    option :verbose, type: :boolean, aliases: '-V'
     def snyk_mapper
       hdfs = HeimdallTools::SnykMapper.new(File.read(options[:json]), options[:name]).to_hdf
       puts "\r\HDF Generated:\n"
@@ -78,7 +72,6 @@ module HeimdallTools
     long_desc Help.text(:nikto_mapper)
     option :json, required: true, aliases: '-j'
     option :output, required: true, aliases: '-o'
-    option :verbose, type: :boolean, aliases: '-V'
     def nikto_mapper
       hdf = HeimdallTools::NiktoMapper.new(File.read(options[:json])).to_hdf
       File.write(options[:output], hdf)
@@ -90,7 +83,6 @@ module HeimdallTools
     long_desc Help.text(:jfrog_xray_mapper)
     option :json, required: true, aliases: '-j'
     option :output, required: true, aliases: '-o'
-    option :verbose, type: :boolean, aliases: '-V'
     def jfrog_xray_mapper
       hdf = HeimdallTools::JfrogXrayMapper.new(File.read(options[:json])).to_hdf
       File.write(options[:output], hdf)
@@ -102,7 +94,6 @@ module HeimdallTools
     long_desc Help.text(:dbprotect_mapper)
     option :xml, required: true, aliases: '-x'
     option :output, required: true, aliases: '-o'
-    option :verbose, type: :boolean, aliases: '-V'
     def dbprotect_mapper
       hdf = HeimdallTools::DBProtectMapper.new(File.read(options[:xml])).to_hdf
       File.write(options[:output], hdf)
@@ -114,7 +105,6 @@ module HeimdallTools
     long_desc Help.text(:aws_config_mapper)
     # option :custom_mapping, required: false, aliases: '-m'
     option :output, required: true, aliases: '-o'
-    option :verbose, type: :boolean, aliases: '-V'
     def aws_config_mapper
       hdf = HeimdallTools::AwsConfigMapper.new(options[:custom_mapping]).to_hdf
       File.write(options[:output], hdf)
@@ -126,7 +116,6 @@ module HeimdallTools
     long_desc Help.text(:netsparker_mapper)
     option :xml, required: true, aliases: '-x'
     option :output, required: true, aliases: '-o'
-    option :verbose, type: :boolean, aliases: '-V'
     def netsparker_mapper
       hdf = HeimdallTools::NetsparkerMapper.new(File.read(options[:xml])).to_hdf
       File.write(options[:output], hdf)

--- a/lib/heimdall_tools/dbprotect_mapper.rb
+++ b/lib/heimdall_tools/dbprotect_mapper.rb
@@ -13,13 +13,10 @@ IMPACT_MAPPING = {
 module HeimdallTools
   class DBProtectMapper
     def initialize(xml, _name = nil)
-
-      begin
-        dataset = xml_to_hash(xml)
-        @entries = compile_findings(dataset['dataset'])
-      rescue StandardError => e
-        raise "Invalid DBProtect XML file provided Exception: #{e};\nNote that XML must be of kind `Check Results Details`."
-      end
+      dataset = xml_to_hash(xml)
+      @entries = compile_findings(dataset['dataset'])
+    rescue StandardError => e
+      raise "Invalid DBProtect XML file provided Exception: #{e};\nNote that XML must be of kind `Check Results Details`."
     end
 
     def to_hdf

--- a/lib/heimdall_tools/dbprotect_mapper.rb
+++ b/lib/heimdall_tools/dbprotect_mapper.rb
@@ -12,8 +12,7 @@ IMPACT_MAPPING = {
 
 module HeimdallTools
   class DBProtectMapper
-    def initialize(xml, _name = nil, verbose = false)
-      @verbose = verbose
+    def initialize(xml, _name = nil)
 
       begin
         dataset = xml_to_hash(xml)

--- a/lib/heimdall_tools/fortify_mapper.rb
+++ b/lib/heimdall_tools/fortify_mapper.rb
@@ -7,9 +7,8 @@ DEFAULT_NIST_TAG = %w{SA-11 RA-5}.freeze
 
 module HeimdallTools
   class FortifyMapper
-    def initialize(fvdl, verbose = false)
+    def initialize(fvdl)
       @fvdl = fvdl
-      @verbose = verbose
 
       begin
         data = xml_to_hash(fvdl)

--- a/lib/heimdall_tools/jfrog_xray_mapper.rb
+++ b/lib/heimdall_tools/jfrog_xray_mapper.rb
@@ -27,9 +27,8 @@ end
 
 module HeimdallTools
   class JfrogXrayMapper
-    def initialize(xray_json, _name = nil, verbose = false)
+    def initialize(xray_json, _name = nil)
       @xray_json = xray_json
-      @verbose = verbose
 
       begin
         @cwe_nist_mapping = parse_mapper

--- a/lib/heimdall_tools/nessus_mapper.rb
+++ b/lib/heimdall_tools/nessus_mapper.rb
@@ -39,9 +39,8 @@ end
 
 module HeimdallTools
   class NessusMapper
-    def initialize(nessus_xml, verbose = false)
+    def initialize(nessus_xml)
       @nessus_xml = nessus_xml
-      @verbose = verbose
       read_cci_xml
       begin
         @cwe_nist_mapping = parse_mapper

--- a/lib/heimdall_tools/netsparker_mapper.rb
+++ b/lib/heimdall_tools/netsparker_mapper.rb
@@ -22,17 +22,14 @@ DEFAULT_NIST_TAG = %w{SA-11 RA-5}.freeze
 module HeimdallTools
   class NetsparkerMapper
     def initialize(xml, _name = nil)
+      @cwe_nist_mapping = parse_mapper(CWE_NIST_MAPPING_FILE)
+      @owasp_nist_mapping = parse_mapper(OWASP_NIST_MAPPING_FILE)
+      data = xml_to_hash(xml)
 
-      begin
-        @cwe_nist_mapping = parse_mapper(CWE_NIST_MAPPING_FILE)
-        @owasp_nist_mapping = parse_mapper(OWASP_NIST_MAPPING_FILE)
-        data = xml_to_hash(xml)
-
-        @vulnerabilities = data['netsparker-enterprise']['vulnerabilities']['vulnerability']
-        @scan_info = data['netsparker-enterprise']['target']
-      rescue StandardError => e
-        raise "Invalid Netsparker XML file provided Exception: #{e}"
-      end
+      @vulnerabilities = data['netsparker-enterprise']['vulnerabilities']['vulnerability']
+      @scan_info = data['netsparker-enterprise']['target']
+    rescue StandardError => e
+      raise "Invalid Netsparker XML file provided Exception: #{e}"
     end
 
     def to_hdf

--- a/lib/heimdall_tools/netsparker_mapper.rb
+++ b/lib/heimdall_tools/netsparker_mapper.rb
@@ -21,8 +21,7 @@ DEFAULT_NIST_TAG = %w{SA-11 RA-5}.freeze
 
 module HeimdallTools
   class NetsparkerMapper
-    def initialize(xml, _name = nil, verbose = false)
-      @verbose = verbose
+    def initialize(xml, _name = nil)
 
       begin
         @cwe_nist_mapping = parse_mapper(CWE_NIST_MAPPING_FILE)

--- a/lib/heimdall_tools/nikto_mapper.rb
+++ b/lib/heimdall_tools/nikto_mapper.rb
@@ -26,9 +26,8 @@ end
 
 module HeimdallTools
   class NiktoMapper
-    def initialize(nikto_json, _name = nil, verbose = false)
+    def initialize(nikto_json, _name = nil)
       @nikto_json = nikto_json
-      @verbose = verbose
 
       begin
         @nikto_nist_mapping = parse_mapper

--- a/lib/heimdall_tools/snyk_mapper.rb
+++ b/lib/heimdall_tools/snyk_mapper.rb
@@ -29,9 +29,8 @@ end
 
 module HeimdallTools
   class SnykMapper
-    def initialize(synk_json, _name = nil, verbose = false)
+    def initialize(synk_json, _name = nil)
       @synk_json = synk_json
-      @verbose = verbose
 
       begin
         @cwe_nist_mapping = parse_mapper

--- a/lib/heimdall_tools/zap_mapper.rb
+++ b/lib/heimdall_tools/zap_mapper.rb
@@ -12,9 +12,8 @@ DEFAULT_NIST_TAG = %w{SA-11 RA-5}.freeze
 
 module HeimdallTools
   class ZapMapper
-    def initialize(zap_json, name, verbose = false)
+    def initialize(zap_json, name)
       @zap_json = zap_json
-      @verbose = verbose
 
       begin
         data = JSON.parse(zap_json, symbolize_names: true)


### PR DESCRIPTION
Not all of the mappers have it.  There are no writes gated behind that parameter.  The cli has not hooked up that parameter to the mappers so they were all using the default value of false.  No user/customer has asked about this functionality.

Conclusion: cleanup dead code

Signed-off-by: Amndeep Singh Mann <amann@mitre.org>